### PR TITLE
Dev.ej/relax click

### DIFF
--- a/g2p/mappings/create_fallback_mapping.py
+++ b/g2p/mappings/create_fallback_mapping.py
@@ -15,7 +15,6 @@ def align_to_dummy_fallback(
     mapping: Mapping,
     io: str = "in",
     distance: str = "weighted_feature_edit_distance",
-    quiet=False,
 ):
     """Create a mapping from mapping's output inventory to a minimalist dummy inventory"""
     mapping_config = mapping.model_dump()
@@ -27,7 +26,7 @@ def align_to_dummy_fallback(
     default_char = "t"
     if is_ipa(mapping_config[f"{io}_lang"]):
         list_of_rules = align_inventories(
-            mapping.inventory(io), DUMMY_INVENTORY, distance=distance, quiet=quiet
+            mapping.inventory(io), DUMMY_INVENTORY, distance=distance
         )
     else:
         und_g2p = make_g2p("und", "und-ipa", tokenize=False)
@@ -39,10 +38,7 @@ def align_to_dummy_fallback(
             for x in mapping.inventory(io)
         ]
         dummy_list = align_inventories(
-            [x["out"] for x in list_of_rules],
-            DUMMY_INVENTORY,
-            distance=distance,
-            quiet=quiet,
+            [x["out"] for x in list_of_rules], DUMMY_INVENTORY, distance=distance
         )
         dummy_dict = {}
         for x in dummy_list:

--- a/g2p/mappings/create_ipa_mapping.py
+++ b/g2p/mappings/create_ipa_mapping.py
@@ -15,8 +15,6 @@
 import datetime as dt
 from typing import Iterable, List, Tuple
 
-from tqdm import tqdm
-
 from g2p.constants import DISTANCE_METRICS
 from g2p.log import LOGGER
 from g2p.mappings import Mapping
@@ -90,7 +88,6 @@ def create_multi_mapping(
     src_mappings: List[Tuple[Mapping, str]],
     tgt_mappings: List[Tuple[Mapping, str]],
     distance: str = "weighted_feature_edit_distance",
-    quiet=False,
 ) -> Mapping:
     """Create a mapping for a set of source mappings to a set of target mappings
 
@@ -145,9 +142,7 @@ def create_multi_mapping(
         tgt_inventory.extend(mapping.inventory(io))
     tgt_inventory = deduplicate(tgt_inventory)
 
-    mapping = align_inventories(
-        src_inventory, tgt_inventory, distance=distance, quiet=quiet
-    )
+    mapping = align_inventories(src_inventory, tgt_inventory, distance=distance)
 
     config = {
         "in_lang": compact_ipa_names(map_1_names),
@@ -172,7 +167,6 @@ def create_mapping(
     mapping_1_io: str = "out",
     mapping_2_io: str = "in",
     distance: str = "weighted_feature_edit_distance",
-    quiet=False,
 ) -> Mapping:
     """Create a mapping from mapping_1's output inventory to mapping_2's input inventory"""
 
@@ -195,7 +189,6 @@ def create_mapping(
         l1_is_xsampa,
         l2_is_xsampa,
         distance=distance,
-        quiet=quiet,
     )
 
     # Initialize mapping with input language parameters (as_is,
@@ -222,7 +215,6 @@ def align_inventories(
     l1_is_xsampa=False,
     l2_is_xsampa=False,
     distance="weighted_feature_edit_distance",
-    quiet=False,
 ):
     """Align inventories by finding a good sequence in inventory_l2 for each
     character in inventory_l1"""
@@ -287,16 +279,9 @@ def align_inventories(
         return "".join(good_match)
 
     mapping = []
-    if not quiet:
-        pbar = tqdm(total=100)
-    step = 1 / len(inventory_l1) * 100
     for i1, p1 in enumerate(process_characters(inventory_l1, l1_is_xsampa)):
         # we enumerate the strings because we want to save the original string
         # (e.g., 'kʷ') to the mapping, not the processed one (e.g. 'kw')
         good_match = find_good_match(p1, inventory_l2)
         mapping.append({"in": inventory_l1[i1], "out": good_match})
-        if not quiet:
-            pbar.update(step)
-    if not quiet:
-        pbar.close()
     return mapping

--- a/g2p/tests/test_cli.py
+++ b/g2p/tests/test_cli.py
@@ -286,7 +286,7 @@ class CliTest(TestCase):
 
         result = self.runner.invoke(doctor, "-m eng-arpabet")
         self.assertEqual(result.exit_code, 0)
-        self.assertIn("No checks implemented", result.stdout)
+        self.assertIn("No checks implemented", result.output)
 
     def test_doctor_lists(self):
         result = self.runner.invoke(doctor, "--list-all")

--- a/g2p/tests/test_create_mapping.py
+++ b/g2p/tests/test_create_mapping.py
@@ -66,7 +66,7 @@ class MappingCreationTest(TestCase):
             {"in": "ᐊ", "out": "a"},
         ]
         src_mapping = Mapping(rules=src_mappings, in_lang="crj", out_lang="crj-ipa")
-        mapping = create_mapping(src_mapping, self.target_mapping, quiet=True)
+        mapping = create_mapping(src_mapping, self.target_mapping)
         transducer = Transducer(mapping)
         self.assertEqual(transducer("a").output_string, "ɑ")
         self.assertEqual(transducer("i").output_string, "i")
@@ -79,7 +79,7 @@ class MappingCreationTest(TestCase):
             {"in": "ᑭ", "out": "ki"},
         ]
         src_mapping = Mapping(rules=src_mappings, in_lang="crj", out_lang="crj-ipa")
-        mapping = create_mapping(src_mapping, self.target_mapping, quiet=True)
+        mapping = create_mapping(src_mapping, self.target_mapping)
         transducer = Transducer(mapping)
         self.assertEqual(transducer("pi").output_string, "pi")
         self.assertEqual(transducer("ti").output_string, "ti")
@@ -92,7 +92,7 @@ class MappingCreationTest(TestCase):
             {"in": "ᒐ", "out": "t͡ʃa"},
         ]
         src_mapping = Mapping(rules=src_mappings, in_lang="crj", out_lang="crj-ipa")
-        mapping = create_mapping(src_mapping, self.target_mapping, quiet=True)
+        mapping = create_mapping(src_mapping, self.target_mapping)
         transducer = Transducer(mapping)
         self.assertEqual(transducer("t͡ʃi").output_string, "tʃi")
         self.assertEqual(transducer("t͡ʃu").output_string, "tʃu")
@@ -105,7 +105,7 @@ class MappingCreationTest(TestCase):
             {"in": "ᒐ", "out": "tSa"},
         ]
         src_mapping = Mapping(rules=src_mappings, in_lang="crj", out_lang="crj-xsampa")
-        mapping = create_mapping(src_mapping, self.target_mapping_xsampa, quiet=True)
+        mapping = create_mapping(src_mapping, self.target_mapping_xsampa)
         transducer = Transducer(mapping)
         self.assertEqual(transducer("tSi").output_string, "tSi")
         self.assertEqual(transducer("tSu").output_string, "tSu")
@@ -118,7 +118,7 @@ class MappingCreationTest(TestCase):
             {"in": "ᐧᑫ", "out": "kʷeː"},
         ]
         src_mapping = Mapping(rules=src_mappings, in_lang="crj", out_lang="crj-ipa")
-        mapping = create_mapping(src_mapping, self.target_mapping, quiet=True)
+        mapping = create_mapping(src_mapping, self.target_mapping)
         transducer = Transducer(mapping)
         self.assertEqual(transducer("pʷeː").output_string, "pweː")
         self.assertEqual(transducer("tʷeː").output_string, "tweː")
@@ -130,31 +130,26 @@ class MappingCreationTest(TestCase):
         # Exercise looking up distances in the known list
         with self.assertRaises(ValueError):
             _ = create_mapping(
-                src_mapping, self.target_mapping, distance="not_a_distance", quiet=True
+                src_mapping, self.target_mapping, distance="not_a_distance"
             )
         with self.assertRaises(ValueError):
             _ = create_multi_mapping(
                 [(src_mapping, "out")],
                 [(self.target_mapping, "in")],
                 distance="not_a_distance",
-                quiet=True,
             )
         # White box testing: monkey-patch an invalid distance to validate the
         # second way we make sure distances are supported
         DISTANCE_METRICS.append("not_a_real_distance")
         with self.assertRaises(ValueError), self.assertLogs(LOGGER, level="ERROR"):
             _ = create_mapping(
-                src_mapping,
-                self.target_mapping,
-                distance="not_a_real_distance",
-                quiet=True,
+                src_mapping, self.target_mapping, distance="not_a_real_distance"
             )
         with self.assertRaises(ValueError), self.assertLogs(LOGGER, level="ERROR"):
             _ = create_multi_mapping(
                 [(src_mapping, "out")],
                 [(self.target_mapping, "in")],
                 distance="not_a_real_distance",
-                quiet=True,
             )
         DISTANCE_METRICS.pop()
 
@@ -167,23 +162,20 @@ class MappingCreationTest(TestCase):
             {"in": "ᕃ", "out": "ʁaj"},
         ]
         src_mapping = Mapping(rules=src_mappings, in_lang="crj", out_lang="crj-ipa")
-        mapping = create_mapping(src_mapping, self.target_mapping, quiet=True)
+        mapping = create_mapping(src_mapping, self.target_mapping)
         # print("mapping", mapping, list(mapping), "distance", "default")
         self.assertTrue(isinstance(mapping, Mapping))
         set_of_mappings = {tuple(rule.rule_output for rule in mapping.rules)}
         for distance in DISTANCE_METRICS:
             mapping = create_mapping(
-                src_mapping, self.target_mapping, distance=distance, quiet=True
+                src_mapping, self.target_mapping, distance=distance
             )
             # print("mapping", mapping, list(mapping), "distance", distance)
             self.assertTrue(isinstance(mapping, Mapping))
             set_of_mappings.add(tuple(rule.rule_output for rule in mapping.rules))
 
             mapping = create_multi_mapping(
-                [(src_mapping, "out")],
-                [(self.target_mapping, "in")],
-                distance=distance,
-                quiet=True,
+                [(src_mapping, "out")], [(self.target_mapping, "in")], distance=distance
             )
             self.assertTrue(isinstance(mapping, Mapping))
             set_of_mappings.add(tuple(rule.rule_output for rule in mapping.rules))

--- a/g2p/tests/test_fallback.py
+++ b/g2p/tests/test_fallback.py
@@ -44,7 +44,7 @@ class FallbackTest(TestCase):
             in_lang="test",
             out_lang="test-ipa",
         )
-        test_in = align_to_dummy_fallback(mapping, quiet=True)
+        test_in = align_to_dummy_fallback(mapping)
         self.assertEqual(
             test_in.rules,
             [
@@ -58,7 +58,7 @@ class FallbackTest(TestCase):
             ],
         )
 
-        test_out = align_to_dummy_fallback(mapping, "out", quiet=True)
+        test_out = align_to_dummy_fallback(mapping, "out")
         self.assertEqual(
             test_out.rules,
             [
@@ -71,7 +71,7 @@ class FallbackTest(TestCase):
                 Rule(rule_input="ةُ", rule_output="ɑu", match_pattern="ةُ"),
             ],
         )
-        test_ipa = align_to_dummy_fallback(ipa_mapping, "out", quiet=True)
+        test_ipa = align_to_dummy_fallback(ipa_mapping, "out")
         panphon_021_ref = [
             Rule(rule_input="æ", rule_output="ɑ", match_pattern="æ"),
             Rule(rule_input="ɐ", rule_output="i", match_pattern="ɐ"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ dependencies = [
   "pyyaml>=5.2",
   "regex",
   "text-unidecode",
-  "tqdm",
   "typing-extensions",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
   "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-  "click>=8.0.4,<8.2.0",
+  "click>=8.0.4",
   "coloredlogs>=15.0.1",
   "openpyxl",
   "ilt-panphon>=0.20.1,<0.22",

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@
 # - pyyaml>=5.2
 # - regex
 # - text-unidecode
-# - tqdm
 # - typing-extensions
 # - fastapi>=0.109.0
 # - starlette>=0.40.0
@@ -88,8 +87,6 @@ starlette==1.0.0
     #   hatch.envs.prod
     #   fastapi
 text-unidecode==1.3
-    # via hatch.envs.prod
-tqdm==4.67.3
     # via hatch.envs.prod
 typing-extensions==4.15.0
     # via


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Clean up dependencies
 - we don't really need tqdm for generate mapping, it runs in seconds -- this changes a fair bit of code because I also removed the `quiet` option that turned that off, but it's all very simple changes
 - we don't actually require click<8.2 as we've been declaring -- adapting to more recent clicks just requires looking at ~`results.stdout + results.stderr` instead of just `results.stdout`; doing so in a try catch lets me remain compatible with old and new versions~  `results.output` instead of `results.stdout`, which is compatible with all versions of click, old and new.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Since g2p is a library, not a stand-alone project, we want its requirements to be as non-restrictive as possible.

### Feedback sought? <!-- What should reviewers focus on in particular? -->

sanity checking

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

low

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

CI tests this well already.

For completeness, I also tested the effect of more recent click on ReadAlongs/Studio and EveryVoice. Both declare `click<8.2` so changing g2p won't break them. I am preparing PRs there too for recent click compatibilty.

### How to test? <!-- Explain how reviewers should test this PR. -->

- Look at CI results

- locally

```
pip install -e .[dev] --upgrade
pytest
```

Watch for `test_cli.py` all passing, that's where I had to fix a failure.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

yes, I'll want to release a patch to publish these relaxed dependencies.

<!-- Add any other relevant information here -->
