### PR TITLE
build: drop Python 3.8 support and testing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.8"
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/matrix-tests.yml
+++ b/.github/workflows/matrix-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.8"
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -131,8 +131,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          # Note: this is where we also test that the g2p library still works on 3.8
-          python-version: "3.8"
+          python-version: "3.9"
       - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true

--- a/g2p/__init__.py
+++ b/g2p/__init__.py
@@ -31,9 +31,9 @@ from typing import Dict, Optional, Tuple, Union
 from g2p.exceptions import InvalidLanguageCode, NeuralDependencyError, NoPath
 from g2p.shared_types import BaseTokenizer, BaseTransducer, Token
 
-if sys.version_info < (3, 8):  # pragma: no cover
+if sys.version_info < (3, 9):  # pragma: no cover
     sys.exit(
-        "Python 3.8 or more recent is required by g2p.\n"
+        "Python 3.9 or more recent is required by g2p.\n"
         f"You are using Python {sys.version}.\n"
         "Please use a newer version of Python."
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,15 +48,13 @@ api = [
   "fastapi>=0.109.0",
   "starlette>=0.40.0",
   "python-socketio>=5.9.0",
-  "python-engineio<4.13; python_version < '3.9'",
   "uvicorn",
   "jinja2",
 ]
 test = [
   "g2p[api]",
   "coverage[toml]>=6.5",
-  "playwright>=1.26.1,<1.46; python_version < '3.9'",
-  "playwright>=1.26.1; python_version >= '3.9'",
+  "playwright>=1.26.1",
   "jsonschema>=4.17.3",
   "pep440>=0.1.2",
   "pytest",
@@ -90,9 +88,9 @@ neural = [
   "g2p[deep-phonemizer]",
 ]
 deep-phonemizer = [
-  "torch>=2.6.0,<2.10; python_version >= '3.9'",
-  "huggingface-hub>0.35.0; python_version >= '3.9'",
-  "ilt-deep-phonemizer>=0.0.23; python_version >= '3.9'",
+  "torch>=2.6.0,<2.10",
+  "huggingface-hub>0.35.0",
+  "ilt-deep-phonemizer>=0.0.23",
 ]
 
 # cannot put g2p[prod] here because that would break windows compat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Module for creating context-aware, rule-based G2P mappings that preserve indices"
 readme = "README.md"
 license = "MIT"
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 authors = [
   { name = "Aidan Pine", email = "hello@aidanpine.ca" },
   { name = "Eric Joanis", email = "eric.joanis@nrc-cnrc.gc.ca" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -170,7 +169,7 @@ default-args = ["g2p/tests"]
 features = ["test", "neural"]
 
 [[tool.hatch.envs.test.matrix]]
-python = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+python = ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
 [tool.hatch.envs.test.scripts]
 serve-cov = "coverage run run_studio.py"


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Python 3.8 is long EOL, and it prevents us from using `uv lock` on Windows. There is no value in keeping it anymore, so let's drop it.

### Feedback sought? <!-- What should reviewers focus on in particular? -->

confirmation we don't need Python 3.8 support anymore

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

normal

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

all well covered

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

not required, but I would like to publish 2.3.2 soon with the recent dependency changes, this drop of 3.8, and the requirements.txt refresh in #493

### Related PR

https://github.com/ReadAlongs/Studio/pull/307

<!-- Add any other relevant information here -->
