### PR TITLE
ci: check json.gz diff with unzipped contents, not compressed

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,7 +93,7 @@ jobs:
           coverage combine
           coverage report
           coverage xml
-          if git status | grep -E 'static.*json|mapping.*pkl|mapping.*.json.gz'; then echo 'g2p databases out of date, please run "g2p update" and commit the results.'; false; else echo OK; fi
+
       - name: Upload coverage information
         uses: codecov/codecov-action@v5
         with:
@@ -118,6 +118,7 @@ jobs:
             echo "Please run 'PYTHONPROFILEIMPORTTIME=1 g2p -h 2> importtime.txt; tuna importtime.txt' and tuck away expensive imports so that the CLI doesn't load them until it uses them."; \
             false; \
           fi
+
       - name: Report help speed in a PR comment
         if: github.event_name == 'pull_request'
         continue-on-error: true
@@ -125,6 +126,21 @@ jobs:
         with:
           preformatted: true
           message-path: import-message.txt
+
+      - name: Make sure g2p databases are up to date
+        # for static/*.json, a straight git status works
+        # for mappings/langs/*.json.gz, bit-for-bit-stable gzip is no longer possible since zlib-ng
+        # replaced zlib in Python 3.14 on Windows and will arrive sooner or later on all platforms.
+        # Ref: https://www.man.com/technology/faster-python
+        run: |
+          OUT_OF_DATE=
+          if git status | grep -E 'static.*json'; then OUT_OF_DATE=1; fi
+          if git status | grep 'mappings.*.json.gz'; then \
+            echo "*.json.gz diff=zcat" > .gitattributes; \
+            git config set diff.zcat.textconv zcat; \
+            if git diff | grep 'mappings.*.json.gz'; then OUT_OF_DATE=1; fi; \
+          fi
+          if [[ $OUT_OF_DATE ]]; then echo 'g2p databases out of date, please run "g2p update" and commit the results.'; false; else echo OK; fi
 
   test-on-windows:
     # Make sure stuff stays compatible with Windows by testing there too.


### PR DESCRIPTION

<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

When checking `mappings/langs/*.json.gz` to see if they are up to date, bit-for-bit-stable gzip is no longer possible since zlib-ng replaced zlib in Python 3.14 on Windows and will arrive sooner or later on all platforms. So we have to diff the unzipped contents, we can no longer rely on just the compressed contents.

See https://www.man.com/technology/faster-python for the a rationale for this change.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

high - partially interferes with #496 and there will be more like it in the future as the faster zlib-ng takes hold

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

n/a

### How to test? <!-- Explain how reviewers should test this PR. -->

 - push a commit where the json.gz files are unchanged but compressed differently -- see CI pass (e.g., https://github.com/NRC-ILT/g2p/actions/runs/28613397570)
 - push a commit where the json.gz files are actually changed -- see CI fail (e.g., https://github.com/NRC-ILT/g2p/actions/runs/28613284328)

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

<!-- Add any other relevant information here -->
