### PR TITLE
fix: g2p update should not rewrite gzip files that are up to date

### DIFF
--- a/g2p/mappings/langs/utils.py
+++ b/g2p/mappings/langs/utils.py
@@ -177,15 +177,31 @@ def cache_langs(
 
 
 def write_json_gz(path: str, data: Any):
+    """Write data into a .json.gz compressed file.
+
+    If the file exists but the contents have not changed, do not rewrite it: gzip output
+    is no longer stable with Python 3.14 starting to replace zlib by the faster zlib-ng,
+    which produces equivalently valid -- but not identical!!! -- compressed output.
+
+    See https://www.man.com/technology/faster-python for more info.
+    """
+    contents = json.dumps(
+        data,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        sort_keys=True,
+    ).encode("utf-8")
+
+    if Path(path).exists():
+        with gzip.open(path, "rb") as f:
+            old_contents = f.read()
+        if contents == old_contents:
+            LOGGER.info(f"{path} already up to date.")
+            return
+
     with gzip.GzipFile(path, "wb", mtime=0) as zipfile:
-        zipfile.write(
-            json.dumps(
-                data,
-                separators=(",", ":"),
-                ensure_ascii=False,
-                sort_keys=True,
-            ).encode("utf-8")
-        )
+        zipfile.write(contents)
+    LOGGER.info(f"{path} updated.")
 
 
 def network_to_echart(outfile: Optional[str] = None, layout: bool = False):
@@ -217,5 +233,5 @@ def network_to_echart(outfile: Optional[str] = None, layout: bool = False):
             newline="\n",
         ) as f:
             f.write(json.dumps({"nodes": nodes, "edges": edges}) + "\n")
-        LOGGER.info("Wrote network nodes and edges to static file.")
+        LOGGER.info(f"Wrote network nodes and edges to static file {outfile}.")
     return nodes, edges

--- a/g2p/tests/test_utils.py
+++ b/g2p/tests/test_utils.py
@@ -3,6 +3,7 @@
 """Test Mapping utility functions"""
 
 import doctest
+import gzip
 import os
 import re
 import sys
@@ -18,6 +19,7 @@ from g2p import get_arpabet_langs
 from g2p._version import VERSION, version_tuple
 from g2p.log import LOGGER
 from g2p.mappings import Mapping, utils
+from g2p.mappings.langs.utils import write_json_gz
 from g2p.mappings.utils import RULE_ORDERING_ENUM, Rule
 from g2p.tests.public import PUBLIC_DIR
 
@@ -349,6 +351,35 @@ class TestUtils:
         with raises(KeyError):
             with warns(DeprecationWarning):
                 _ = t2["bad_key"]
+
+
+def test_write_json_gz(tmp_path, caplog):
+    # write_json_gz should not overwrite a file that exist and is up to date
+    data = {"a": "b", "c": 1, "d": True}
+    file = tmp_path / "foo.json.gz"
+    write_json_gz(file, data)
+
+    # Contents are the same -- do not overwrite
+    with caplog.at_level("INFO", logger=LOGGER.name):
+        write_json_gz(file, data)
+    assert "already up to date" in caplog.text
+    caplog.clear()
+
+    # Contents changed -- overwrite
+    data["e"] = 42
+    with caplog.at_level("INFO", logger=LOGGER.name):
+        write_json_gz(file, data)
+    assert "updated" in caplog.text
+    caplog.clear()
+
+    # Compression changed, but not contents -- do no overwrite
+    with gzip.open(file, "rb") as f:
+        contents = f.read()
+    with gzip.GzipFile(file, "wb", compresslevel=1) as f:
+        f.write(contents)
+    with caplog.at_level("INFO", logger=LOGGER.name):
+        write_json_gz(file, data)
+    assert "already up to date" in caplog.text
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Stabilize `g2p update` output by not rewriting gzipped files that are up-to-date.

Related to #497, going one step further, so that if you get someone else's DB generated from a Python giving you different compressed output, you won't overwrite it (and thus recompress it) unless you've actually caused the file contents to change.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

The risk of flip-flopping *.json.gz files as we each run tests and code stuff on different versions of Python and OSes.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

normal

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

~Thinking about it...~ yes

### How to test? <!-- Explain how reviewers should test this PR. -->

`g2p update` will tell you that the two .json.gz files are up to date

```
gunzip g2p/mappings/langs/langs.json.gz
gzip -1 g2p/mappings/langs/langs.json
g2p update
```

will still tell you that the two .json.gz files are up to date, even though `git status` will say langs.json.gz has changed.

!!! Don't commit that change -- do `git restore g2p/mappings/langs/langs.json.gz` after to undo it.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

<!-- Add any other relevant information here -->
