### PR TITLE
simplify run_test and de-emphasize it

### DIFF
--- a/.github/workflows/matrix-tests.yml
+++ b/.github/workflows/matrix-tests.yml
@@ -29,7 +29,7 @@ jobs:
           python -m pip install --upgrade pip
           SETUPTOOLS_SCM_PRETEND_VERSION=$(cat .SETUPTOOLS_SCM_PRETEND_VERSION) pip install -e .[test]
       - name: Run tests
-        run: python run_tests.py dev
+        run: pytest
 
       # Neural tests, with huggingface models cached
       - name: Get current week number
@@ -41,11 +41,4 @@ jobs:
           key: g2p-neural-${{ steps.weekno.outputs.WEEK_NUMBER }}
           path: ~/.cache/huggingface
       - run: pip install -e .[neural]
-      - run: python g2p/tests/test_neural.py
-
-      # Studio test
-      - name: Launch the API
-        shell: bash
-        run: python run_studio.py &
-      - name: Run test-studio
-        run: python g2p/tests/test_studio.py
+      - run: pytest g2p/tests/test_neural.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -163,7 +163,7 @@ jobs:
         run: |
           SETUPTOOLS_SCM_PRETEND_VERSION=`cat .SETUPTOOLS_SCM_PRETEND_VERSION` uv pip install -e .[test]
       - name: Run tests on Windows
-        run: python run_tests.py dev
+        run: pytest
       - name: Make sure the CLI outputs utf8 on Windows
         run: |
           # Warning: This is PowerShell syntax, not bash!
@@ -209,7 +209,5 @@ jobs:
           bin/post_compile
       - name: Launch the API
         run: ${RUNTIME_CMD} --bind localhost:5000 &
-      - name: Run the regular dev suite
-        run: python run_tests.py dev
-      - name: Run test-studio
-        run: python g2p/tests/test_studio.py
+      - name: Run the tests
+        run: pytest

--- a/Contributing.md
+++ b/Contributing.md
@@ -174,4 +174,4 @@ Then you can run all the test suites by simply invoking `pytest`:
 
     pytest
 
-We also have a `./run_tests.py` script to run selected parts of the test suites. Run `./run_tests.py -h` for info.
+You can also run `./run_tests.py` to run most of the tests, skipping the slow ones.

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ mappings:
 Mappings are defined in either a CSV or json file. See [writing mapping files](#writing-mapping-files) for more info.
 5. Start a development shell with `hatch shell` (or install an editable version with `pip install -e .`) then update with `g2p update`
 6. Add some tests in `g2p/testspublic/data/<YourIsoCode>.psv`. Each line in the file will run a test with the following structure: `<in_lang>|<out_lang>|<input_string>|<expected_output>`
-7. Run `python3 run_tests.py langs` to make sure your tests pass.
+7. Run `pytest g2p/tests/test_langs.py` to make sure your tests pass.
 8. Make sure you have [checked all the boxes](https://github.com/nrc-ilt/g2p/blob/main/.github/pull_request_template.md) and make a [pull request]((https://github.com/nrc-ilt/g2p/pulls)!
 
 ### Adding a new language for support with ReadAlongs

--- a/g2p/tests/run.py
+++ b/g2p/tests/run.py
@@ -5,12 +5,17 @@
 Run with "python run.py <suite>" where <suite> can be all, dev, or slow.
 
 Add --describe to list the contents of the selected suite instead of running it.
+
+Note: this script is no longer the recommended way to run the tests -- instead,
+use pytest -- but it is still supported and should never be deprecated since it
+is mentioned in the 7-part blog post.
 """
 
 import argparse
 import io
 import sys
 from contextlib import redirect_stdout
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Optional
 
@@ -19,11 +24,19 @@ import pytest
 # Unit tests
 from g2p.log import LOGGER
 
-SUITES: Dict[str, List[str]] = {
-    "all": [],  # empty list triggers complete test discovery
-    "dev": [],  # subtractive logic: dev = all - slow
-    "langs": ["test_langs"],  # kept here because part 7 of the 7-part blog mentions it
-    "slow": ["test_studio", "test_neural"],
+
+@dataclass
+class Suite:
+    tests: List[str]
+    description: str
+
+
+SUITES: Dict[str, Suite] = {
+    "all": Suite([], "all tests, using pytest discovery"),  # empty list => discovery
+    "dev": Suite([], "all but the slow tests"),  # subtractive logic: dev = all - slow
+    # "langs" required because part 7 of the 7-part blog mentions it
+    "langs": Suite(["test_langs"], "language mapping tests"),
+    "slow": Suite(["test_studio", "test_neural"], "slow tests"),
 }
 
 
@@ -75,25 +88,24 @@ def run_tests(suite: Optional[str], describe=False, verbose=False) -> bool:
     Returns: Bool: True iff success
     """
     if not suite:
-        LOGGER.info(
-            "No test suite specified, defaulting to 'dev', which skips the slow tests."
-        )
         suite = "dev"
 
     if suite not in SUITES:
         LOGGER.error("Please specify a test suite to run among: " + ", ".join(SUITES))
         return False
 
+    LOGGER.info(f"Running suite '{suite}': {SUITES[suite].description}")
+
     tests_dir = Path(__file__).parent
     if suite == "dev":
-        expensive_files = [tests_dir / f"{file}.py" for file in SUITES["slow"]]
+        expensive_files = [tests_dir / f"{file}.py" for file in SUITES["slow"].tests]
         test_suite_filenames = [
             str(file)
             for file in tests_dir.glob("test*.py")
             if file not in expensive_files
         ]
     else:
-        test_suite = SUITES[suite]
+        test_suite = SUITES[suite].tests
         test_suite_filenames = [str(tests_dir / f"{file}.py") for file in test_suite]
 
     if describe:
@@ -105,7 +117,13 @@ def run_tests(suite: Optional[str], describe=False, verbose=False) -> bool:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Run g2p test suites.")
+    parser = argparse.ArgumentParser(
+        description="Run g2p test suites.\nNote: while this script is still supported, we now recommend using pytest instead.\n\nSuites:\n"
+        + "\n".join(
+            " - " + name + ": " + suite.description for name, suite in SUITES.items()
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     parser.add_argument("--verbose", "-v", action="store_true", help="verbose output")
     parser.add_argument(
         "--describe", action="store_true", help="describe the selected test suite"

--- a/g2p/tests/run.py
+++ b/g2p/tests/run.py
@@ -2,8 +2,7 @@
 
 """Organize tests into Test Suites
 
-Run with "python run.py <suite>" where <suite> can be all, dev, or a few other
-options (see run_tests() for the full list).
+Run with "python run.py <suite>" where <suite> can be all, dev, or slow.
 
 Add --describe to list the contents of the selected suite instead of running it.
 """
@@ -22,42 +21,10 @@ from g2p.log import LOGGER
 
 SUITES: Dict[str, List[str]] = {
     "all": [],  # empty list triggers complete test discovery
-    "dev": [],  # updated below this block
-    "api": ["test_api_resources", "test_api_v2"],
-    "integ": ["test_cli", "test_doctor", "test_doctor_expensive"],  # updated below
-    "langs": ["test_langs"],
-    "mappings": [
-        "test_fallback",
-        "test_create_mapping",
-        "test_mappings",
-        "test_network",
-        "test_utils",
-        "test_tokenizer",
-        "test_tokenize_and_map",
-        "test_check_ipa_arpabet",
-    ],
-    "trans": [
-        "test_indices",
-        "test_transducer",
-        "test_unidecode_transducer",
-        "test_lexicon_transducer",
-    ],
-    # Neural tests are excluded from dev and automatically skipped if neural
-    # dependencies are not installed, because they require torch and other heavy
-    # dependencies and the tests also require downloading large g2p models
-    "neural": ["test_neural"],
-    # Studio is also expensive and excluded from dev
-    "studio": ["test_studio"],
+    "dev": [],  # subtractive logic: dev = all - slow
+    "langs": ["test_langs"],  # kept here because part 7 of the 7-part blog mentions it
+    "slow": ["test_studio", "test_neural"],
 }
-SUITES["dev"] = sum(
-    [SUITES[suite] for suite in ("api", "integ", "langs", "trans", "mappings")],
-    start=[],
-)
-# LocalConfigTest has to get run last, to avoid interactions with other test
-# cases, since it has side effects on the global database
-SUITES["dev"] += ["test_z_local_config"]
-
-SUITES["integ"] += SUITES["api"]
 
 
 class PytestCollectorPlugin:
@@ -109,7 +76,7 @@ def run_tests(suite: Optional[str], describe=False, verbose=False) -> bool:
     """
     if not suite:
         LOGGER.info(
-            "No test suite specified, defaulting to 'dev', which skips the slowest tests."
+            "No test suite specified, defaulting to 'dev', which skips the slow tests."
         )
         suite = "dev"
 
@@ -117,9 +84,18 @@ def run_tests(suite: Optional[str], describe=False, verbose=False) -> bool:
         LOGGER.error("Please specify a test suite to run among: " + ", ".join(SUITES))
         return False
 
-    test_suite = SUITES[suite]
     tests_dir = Path(__file__).parent
-    test_suite_filenames = [str(tests_dir / f"{file}.py") for file in test_suite]
+    if suite == "dev":
+        expensive_files = [tests_dir / f"{file}.py" for file in SUITES["slow"]]
+        test_suite_filenames = [
+            str(file)
+            for file in tests_dir.glob("test*.py")
+            if file not in expensive_files
+        ]
+    else:
+        test_suite = SUITES[suite]
+        test_suite_filenames = [str(tests_dir / f"{file}.py") for file in test_suite]
+
     if describe:
         describe_suite(suite, test_suite_filenames)
         return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,9 @@ include = ["/g2p"]
 [tool.hatch.env]
 requires = ["hatch-pip-compile"]
 
+[tool.hatch.envs.default]
+features = ["dev"]
+
 [tool.hatch.envs.api]
 features = ["api"]
 
@@ -171,9 +174,8 @@ python = ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
 [tool.hatch.envs.test.scripts]
 serve-cov = "coverage run run_studio.py"
-test = "python run_tests.py dev"
-test-cov = "coverage run run_tests.py dev"
-test-studio = "python g2p/tests/test_studio.py"
+test = "pytest"
+test-cov = "coverage run pytest"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

`run_tests.py` is mostly useless now that `pytest` is the standard way to run tests.
 - it gets stale whenever we add new test files
 - just running `pytest` is not harder! it's simpler

So:
 - adjust the documentation to tell people to use pytest, except for the one case where it kinda still has value: `./run_tests.py` skips the slow tests by default
 - strip all the pointless suites in run_tests
 - redefine `dev` subtractively so it auto-maintains itself: `dev = all - slow` where `slow` is explicitly defined instead
 - keep `run_tests.py langs` because the 7-part blog post mentions it, but still change `Contributing.md` to say `pytest g2p/tests/test_langs.py` instead, which is the recommended way now.
 - adjust the hatch configuration so you get a `dev` env by default: we'd never want to run `hatch shell` and not be able to run the tests.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

removes stales stuff

### Feedback sought? <!-- What should reviewers focus on in particular? -->

nothing specific

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

low

### How to test? <!-- Explain how reviewers should test this PR. -->

- CI passes
- `pytest` runs all the tests
- `./run_tests.py --describe dev` confirms that `dev` runs all but the slow tests

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

<!-- Add any other relevant information here -->
